### PR TITLE
add  --overwrite option

### DIFF
--- a/tutorials/cadastre.rst
+++ b/tutorials/cadastre.rst
@@ -56,17 +56,17 @@ tutorial, it is expected, that you place the data in
 .. code-block:: bash
 
     # create the SRTM DEM dataset
-    generatevrtwo N50E014.tif /var/vts/mapproxy/datasets/srtm --resampling dem --tiliseSize 1024x1024
-    generatevrtwo N50E014.tif /var/vts/mapproxy/datasets/srtm.min --resampling min --tiliseSize 1024x1024
-    generatevrtwo N50E014.tif /var/vts/mapproxy/datasets/srtm.max --resampling max --tiliseSize 1024x1024
+    generatevrtwo N50E014.tif /var/vts/mapproxy/datasets/srtm --resampling dem --tiliseSize 1024x1024 --overwrite
+    generatevrtwo N50E014.tif /var/vts/mapproxy/datasets/srtm.min --resampling min --tiliseSize 1024x1024 --overwrite
+    generatevrtwo N50E014.tif /var/vts/mapproxy/datasets/srtm.max --resampling max --tiliseSize 1024x1024 --overwrite
     ln -s srtm/dataset srtm/dem
     ln -s srtm.min/dataset srtm/dem.min
     ln -s srtm.max/dataset srtm/dem.max
     
     # create Jensten dataset
-    generatevrtwo jenstejn-dem.tif /var/vts/mapproxy/datasets/jenstejn-dem --resampling dem --tiliseSize 1024x1024
-    generatevrtwo jenstejn-dem.tif /var/vts/mapproxy/datasets/jenstejn-dem.min --resampling min --tiliseSize 1024x1024
-    generatevrtwo jenstejn-dem.tif /var/vts/mapproxy/datasets/jenstejn-dem.max --resampling max --tiliseSize 1024x1024
+    generatevrtwo jenstejn-dem.tif /var/vts/mapproxy/datasets/jenstejn-dem --resampling dem --tiliseSize 1024x1024 --overwrite
+    generatevrtwo jenstejn-dem.tif /var/vts/mapproxy/datasets/jenstejn-dem.min --resampling min --tiliseSize 1024x1024 --overwrite
+    generatevrtwo jenstejn-dem.tif /var/vts/mapproxy/datasets/jenstejn-dem.max --resampling max --tiliseSize 1024x1024 --overwrite
     ln -s jenstejn-dem/dataset jenstejn-dem/dem
     ln -s jenstejn-dem.min/dataset jenstejn-dem/dem.min
     ln -s jenstejn-dem.max/dataset jenstejn-dem/dem.max


### PR DESCRIPTION
Otherwise you get an error like
```

vts@BG-test-soft-3D-FN:~/mapproxy/datasets/srtm$ generatevrtwo N50E014.tif /var/vts/mapproxy/datasets/srtm --resampling dem --tileSize 1024x1024
2017-07-24 15:34:01 I3 [2411(main)]: [generageVrtWo] Config:
        input = "/var/vts/mapproxy/datasets/srtm/N50E014.tif"
        output = "/var/vts/mapproxy/datasets/srtm"
        tileSize = 1024x1024
        resampling = dem
        minOvrSize = 256x256
        wrapx = false
        background = none
        co =
 {main.cpp:configure():318}
2017-07-24 15:34:01 FF [2411(main)]: Destination directory already exits. Use --overwrite to force rewrite. {main.cpp:run():1147}
2017-07-24 15:34:01 E4 [2411(main)]: [generageVrtWo] Terminated with error 1. {cmdline.cpp:operator()():60}
```